### PR TITLE
Update the runtime version from 24.08 to 25.08, and more

### DIFF
--- a/org.dhewm3.Dhewm3.metainfo.xml
+++ b/org.dhewm3.Dhewm3.metainfo.xml
@@ -1,32 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright 2021 Kevin Degeling -->
-
-<component type="desktop">
+<component type="desktop-application">
   <id>org.dhewm3.Dhewm3</id>
   <name>Dhewm 3</name>
-  <summary>dhewm 3 is a Doom 3 GPL source port</summary>
+  <summary>Dhewm 3 is a Doom 3 GPL source port</summary>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3.0</project_license>
 
-  <developer_name>Dhewm 3 team</developer_name>
+  <developer id="org.dhewm3">
+    <name>Dhewm 3 team</name>
+  </developer>
   <update_contact>eonfge@kevindegeling.nl</update_contact>
 
   <url type="homepage">https://dhewm3.org</url>
   <url type="help">https://github.com/dhewm/dhewm3/wiki/FAQ</url>
-  <url type="bugtracker">https://github.com/dhewm/dhewm3</url>
+  <url type="bugtracker">https://github.com/dhewm/dhewm3/issues</url>
+  <url type="vcs-browser">https://github.com/dhewm/dhewm3</url>
 
   <launchable type="desktop-id">org.dhewm3.Dhewm3.desktop</launchable>
 
   <description>
-    <p>Dhewm 3 is a source port of the original Doom 3 (not Doom 3 BFG, for that you may want to try RBDoom3BFG). It's known to work on Windows, Linux, macOS, FreeBSD, OpenBSD and AROS, but it should work on (or be easily portable to) any system that supports OpenGL 1.4 with ARB shaders, SDL and OpenAL.
+    <p>Dhewm 3 is a source port of the original Doom 3 (not Doom 3 BFG, for that you may
+      want to try RBDoom3BFG). It's known to work on Windows, Linux, macOS, FreeBSD,
+      OpenBSD and AROS, but it should work on (or be easily portable to) any system that
+      supports OpenGL 1.4 with ARB shaders, SDL and OpenAL.
     </p>
-    <p>Compared to the original version of Doom 3, Dhewm 3 has many bugfixes, supports EAX-like sound effects on all operating systems and hardware (via OpenAL Softs EFX support), has much better support for widescreen resolutions and has 64bit support.
+    <p>Compared to the original version of Doom 3, Dhewm 3 has many bugfixes,
+      supports EAX-like sound effects on all operating systems and hardware
+      (via OpenAL Softs EFX support), has much better support for widescreen
+      resolutions and has 64bit support.
     </p>
-    <p>It only supports old Mods if they either don't require their own game DLL or have been ported to Dhewm 3 - see the Mods page for more information.
+    <p>It only supports old Mods if they either don't require their own game
+      DLL or have been ported to Dhewm 3 - see the Mods page for more information.
     </p>
     <p>Mod-binaries who are supported, are bundled with Dhewm 3. External data is still required.
     </p>
-    <p>Note that while the Doom 3 source code has been released under GPL, you still need to legally own the game and provide Dhewm 3 the game data to play. See the How to Install section for more information.
+    <p>Note that while the Doom 3 source code has been released under GPL, you still need to
+      legally own the game and provide Dhewm 3 the game data to play. See the How to Install
+      section for more information.
     </p>
   </description>
 

--- a/org.dhewm3.Dhewm3.yaml
+++ b/org.dhewm3.Dhewm3.yaml
@@ -1,7 +1,7 @@
 app-id: org.dhewm3.Dhewm3
 runtime: org.freedesktop.Platform
 sdk: org.freedesktop.Sdk
-runtime-version: '24.08'
+runtime-version: '25.08'
 command: dhewm3.sh
 
 finish-args:
@@ -34,6 +34,7 @@ modules:
     config-opts:
       - -DCMAKE_BUILD_TYPE=RelWithDebInfo
       - -DREPRODUCIBLE_BUILD=ON
+      - -DCMAKE_EXE_LINKER_FLAGS=-lcurl
     sources:
       - type: archive
         url: https://github.com/dhewm/dhewm3/archive/refs/tags/1.5.4.tar.gz
@@ -108,6 +109,7 @@ modules:
     no-make-install: true
     config-opts:
       - -DCMAKE_BUILD_TYPE=RelWithDebInfo
+      - -DCMAKE_POLICY_VERSION_MINIMUM=3.5
     post-install:
       - install -Dm 755 librecoop.so /app/lib/dhewm3
     sources:
@@ -179,6 +181,12 @@ modules:
 
   - name: launcher
     buildsystem: simple
+    build-commands:
+      - install -Dm 644 org.dhewm3.Dhewm3.desktop -t /app/share/applications
+      - install -Dm 644 org.dhewm3.Dhewm3.d3xp.desktop -t /app/share/applications
+      - install -Dm 644 org.dhewm3.Dhewm3.metainfo.xml -t /app/share/metainfo
+      - install -Dm 744 dhewm3.sh -t /app/bin/
+      - install -Dm 744 dhewm3_d3xp.sh -t /app/bin/
     sources:
       - type: file
         path: org.dhewm3.Dhewm3.desktop
@@ -200,9 +208,3 @@ modules:
             --ok-label "Close" --width=400
           - dhewm3 +set fs_game d3xp "$@"
         dest-filename: dhewm3_d3xp.sh
-    build-commands:
-      - install -Dm 644 org.dhewm3.Dhewm3.desktop -t /app/share/applications
-      - install -Dm 644 org.dhewm3.Dhewm3.d3xp.desktop -t /app/share/applications
-      - install -Dm 644 org.dhewm3.Dhewm3.metainfo.xml -t /app/share/metainfo
-      - install -Dm 744 dhewm3.sh -t /app/bin/
-      - install -Dm 744 dhewm3_d3xp.sh -t /app/bin/


### PR DESCRIPTION
- Update the runtime version to 25.08
- Fix build errors
- Comply with Flathub styling guidelines
- Fix appdata paper cuts

See: https://docs.flathub.org/docs/for-app-authors/requirements#flatpak-builder-manifest-style-guide